### PR TITLE
Add space after commentStart and before commentEnd

### DIFF
--- a/lib/block-comment-plus.js
+++ b/lib/block-comment-plus.js
@@ -25,8 +25,8 @@ function toggle() {
       let endLanguage = getLanguage(bufferRange.end);
 
       // defaults to C based comments
-      let commentStart = '/*';
-      let commentEnd = '*/';
+      let commentStart = '/* ';
+      let commentEnd = ' */';
       let addNewLine = false;
 
       if (startLanguage !== endLanguage || startLanguage === "plain") {


### PR DESCRIPTION
As mentioned in #4 it would be nice to have a space after the commentStart and before the commentEnd.
